### PR TITLE
Add Spek integration

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -14,6 +14,9 @@ ext {
     // Spark
     spark_kotlin_version = '1.0.0-alpha'
 
+    // Spek
+    spek_version = '1.1.5'
+
     // Test
     junit_version = "4.12"
     mockito_version = "2.8.47"

--- a/koin-spek/build.gradle
+++ b/koin-spek/build.gradle
@@ -1,0 +1,43 @@
+
+archivesBaseName = 'koin-spek'
+description = 'Koin - simple dependency injection for Kotlin - ' + archivesBaseName
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.0'
+    }
+}
+
+apply plugin: 'org.junit.platform.gradle.plugin'
+
+junitPlatform {
+    filters {
+        engines {
+            include 'spek'
+        }
+    }
+}
+
+repositories {
+    maven { url "http://dl.bintray.com/jetbrains/spek" }
+}
+
+dependencies {
+    compile fileTree(dir: 'libs', include: ['*.jar'])
+
+    // Koin
+    compile project(":koin-core")
+
+    compile "junit:junit:$junit_version"
+    testCompile "org.mockito:mockito-core:$mockito_version"
+
+    // Spek
+    compile "org.jetbrains.spek:spek-api:$spek_version"
+    testCompile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+    testCompile "org.jetbrains.spek:spek-api:$spek_version"
+    testRuntime "org.jetbrains.spek:spek-junit-platform-engine:$spek_version"
+}

--- a/koin-spek/src/main/kotlin/org/koin/spek/KoinSpek.kt
+++ b/koin-spek/src/main/kotlin/org/koin/spek/KoinSpek.kt
@@ -1,0 +1,31 @@
+package org.koin.spek
+
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.Spec
+import org.jetbrains.spek.api.dsl.TestBody
+import org.jetbrains.spek.api.lifecycle.GroupScope
+import org.jetbrains.spek.api.lifecycle.LifecycleListener
+import org.koin.KoinContext
+import org.koin.core.parameter.Parameters
+import org.koin.standalone.KoinComponent
+import org.koin.standalone.StandAloneContext
+
+class KoinSpec(val root: Spec) : KoinComponent, Spec by root
+
+abstract class KoinSpek(koinSpec: KoinSpec.() -> Unit): Spek({
+    koinSpec.invoke(KoinSpec(this))
+})
+
+abstract class AutoCloseKoinSpek(koinSpec: KoinSpec.() -> Unit): KoinSpek({
+    registerListener(object: LifecycleListener {
+        override fun afterExecuteGroup(group: GroupScope) {
+            StandAloneContext.closeKoin()
+        }
+    })
+
+    koinSpec.invoke(this)
+})
+
+fun TestBody.dryRun(defaultParameters: Parameters = { kotlin.collections.emptyMap() }) {
+    (org.koin.standalone.StandAloneContext.koinContext as KoinContext).dryRun(defaultParameters)
+}

--- a/koin-spek/src/test/kotlin/org/koin/spek/KoinDSLTest.kt
+++ b/koin-spek/src/test/kotlin/org/koin/spek/KoinDSLTest.kt
@@ -1,0 +1,31 @@
+package org.koin.spek
+
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import org.junit.Assert
+import org.koin.dsl.module.applicationContext
+import org.koin.standalone.StandAloneContext
+import org.koin.standalone.inject
+
+class HelloService
+class WorldService(val service: HelloService)
+
+val module = applicationContext {
+    factory { HelloService() }
+    bean { WorldService(get()) }
+}
+
+class KoinDSLTest : AutoCloseKoinSpek({
+    describe("DSL") {
+        it("is possible to use inject") {
+            StandAloneContext.startKoin(listOf(module))
+
+            val worldService: WorldService by inject()
+            Assert.assertNotNull(worldService.service)
+        }
+
+        it("is possible to use dryRun") {
+            dryRun()
+        }
+    }
+})

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':koin-core', ':koin-test', 'koin-ktor', 'koin-spark'
+include ':koin-core', ':koin-test', 'koin-ktor', 'koin-spark', 'koin-spek'


### PR DESCRIPTION
Most of the extending functionality is from this issue explaining how to extend Spek: https://github.com/spekframework/spek/issues/115

The integration happens by injecting `KoinComponent` to `Spec` class. This enables Koin DSL to be used within Spek tests. `KoinSpek.kt` adds `AutoCloseKoinSpek` class similar to `AutoCloseKoinTest` class.

## Usage

Add `koin-spek` as dependency, e.g.

```
    testCompile "org.koin:koin-spek:$koin_version"
```

Switch `Spek` class to `KoinSpek` (or `AutoCloseKoinSpek`) and write the tests normally. Here is minimal example:

```kotlin
class HelloService

val module = applicationContext {
    bean { HelloService() }
}

class KoinDSLTest : AutoCloseKoinSpek({
    describe("DSL") {
        it("is possible to use inject") {
            StandAloneContext.startKoin(listOf(module))

            val helloService: HelloService by inject()
            Assert.assertNotNull(helloService)
        }
    }
})
```

`KoinDSLTest.kt` contains the full example.

Spek requires quite a bit of runtime dependencies that are not needed on compile time. I'm not sure whether it is feasible to include in `build.gradle` file or not. If not, I'm happy to take the tests away.